### PR TITLE
Issuer prefixed label is optional but some apps use it

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,9 +202,11 @@ function generate_uri() {
   const issuer = $("#issuer").val();
   const advanced_options = $("#advanced_options").prop("checked");
 
-  let uri = `otpauth://${type}/${encodeURIComponent(label)}?secret=${secret}`;
+  let uri = `otpauth://${type}/`;
   if (issuer != "") {
-    uri += `&issuer=${encodeURIComponent(issuer)}`;
+    uri += `${encodeURIComponent(issuer)}:${encodeURIComponent(label)}?secret=${secret}&issuer=${encodeURIComponent(issuer)}`;
+  }else{
+    uri += `${encodeURIComponent(label)}?secret=${secret}`;
   }
   if (type == "hotp") {
     const counter = $("#counter").val() || "0";


### PR DESCRIPTION
Issuer prefixed label is optional but some apps use it instead the issuer parameter like old versions of Google Authenticator and FreeOTP+. I didn't test others.